### PR TITLE
bugfix for uneven sample size

### DIFF
--- a/wave_python/waveletFunctions.py
+++ b/wave_python/waveletFunctions.py
@@ -113,9 +113,9 @@ def wavelet(Y, dt, pad=0, dj=-1, s0=-1, J1=-1, mother=-1, param=-1):
     n = len(x)
 
     #....construct wavenumber array used in transform [Eqn(5)]
-    kplus = np.arange(1, np.fix(n / 2 + 1))
+    kplus = np.arange(1, n / 2 + 1)
     kplus = (kplus * 2 * np.pi / (n * dt))
-    kminus = (-(kplus[0:-1])[::-1])
+    kminus = (-(kplus[0:(n-1)/2])[::-1])
     k = np.concatenate(([0.], kplus, kminus))
 
     #....compute FFT of the (padded) time series


### PR DESCRIPTION
I have stumbled over a minor bug in the python
function **waveletFunctions.py**: If you run the code on a time series of uneven
length (e.g. `len(x)=101`), it returns "*ValueError: operands could not be
broadcast together with shapes (101,) (100,)*" as the Fourier transform f
and the daughter have different sizes. You may check this via

```
import numpy as np
from waveletFunctions import wavelet

x = np.random.randn(101)
dt = 1.0
w = wavelet ( x, dt )
```

The problem is in the construction of the wave vector k. Here, the last
entry of the `kplus` vector is always omitted (`kplus[0:-1]`). However, in
case of uneven length of the time series, the Fourier transform returns
no value for the Nyquist frequency and therefore the last entry of wave
vector kplus should be used as well. I found that the following lines
replacing **lines 115-119** solve this problem:

```
#....construct wavenumber array used in transform [Eqn(5)]
kplus = np.arange(1, n/2+1)
kplus = (kplus * 2 * np.pi / (n * dt))
kminus = (-(kplus[0:(n-1)/2])[::-1])
k = np.concatenate(([0.], kplus, kminus))
```

Here, I simply replaced `kplus[0:-1]` by `kplus[0:(n-1)/2]`. The np.fix
function is actually not needed as dividing by integer automatically
takes care of rounding down.

Best regards,
Mitch