### PR TITLE
Bug fix for length of k and period variable remaining undeclared 

### DIFF
--- a/wave_python/waveletFunctions.py
+++ b/wave_python/waveletFunctions.py
@@ -115,9 +115,10 @@ def wavelet(Y, dt, pad=0, dj=-1, s0=-1, J1=-1, mother=-1, param=-1, freq=None):
     n = len(x)
 
     #....construct wavenumber array used in transform [Eqn(5)]
-    kplus = np.arange(1, n / 2 + 1)
+    kplus = np.arange(1, int(n / 2) + 1)
     kplus = (kplus * 2 * np.pi / (n * dt))
-    kminus = (-(kplus[0:(n-1)/2])[::-1])
+    kminus = np.arange(1, int((n-1) / 2) + 1)
+    kminus = np.sort((-kminus * 2 * np.pi / (n * dt)))
     k = np.concatenate(([0.], kplus, kminus))
 
     #....compute FFT of the (padded) time series

--- a/wave_python/waveletFunctions.py
+++ b/wave_python/waveletFunctions.py
@@ -143,6 +143,8 @@ def wavelet(Y, dt, pad=0, dj=-1, s0=-1, J1=-1, mother=-1, param=-1, freq=None):
     if freq is None:
         j = np.arange(0, J1+1)
         scale = s0 * 2. ** (j * dj)
+        freq = 1./(fourier_factor*scale)
+        period = 1./freq
     else:
         scale = 1./(fourier_factor*freq)
         period = 1./freq


### PR DESCRIPTION
Fixes two errors:

- Avoid mismatch between len(k) and and len(f). Tested for n=1000 and n=2001 and compared to Matlab code. 
- Declare a freq vector from scales if freq==None (otherwise, period is never defined yet returned by the function). 