### PR TITLE
Fix bug in chisquare_inv.m related to vers variable parsing in MATLAB versions >= 10

### DIFF
--- a/wave_matlab/chisquare_inv.m
+++ b/wave_matlab/chisquare_inv.m
@@ -23,19 +23,12 @@ function X = chisquare_inv(P,V);
 	MAXX = 1;            % actually starts at 10 (see while loop below)
 	X = 1;
 	TOLERANCE = 1E-4;    % this should be accurate enough
-    vers = version;
-    vers = str2num(vers(1));
 
 	while ((X+TOLERANCE) >= MAXX)  % should only need to loop thru once
-		MAXX = MAXX*10.;
-% this calculates value for X, NORMALIZED by V
-% Note: We need two different versions, depending upon the version of Matlab.
-        if (vers >= 6)
-            X = fminbnd('chisquare_solve',MINN,MAXX,optimset('TolX',TOLERANCE),P,V);
-        else
-    		X = fmin('chisquare_solve',MINN,MAXX,[0,TOLERANCE],P,V);
-        end
-		MINN = MAXX;
+        MAXX = MAXX*10.;
+        % this calculates value for X, NORMALIZED by V
+        X = fminbnd('chisquare_solve',MINN,MAXX,optimset('TolX',TOLERANCE),P,V);
+        MINN = MAXX;
 	end
 	
 	X = X*V;  % put back in the goofy V factor


### PR DESCRIPTION
In the wave_matlab/chisquare_inv.m script, the vers variable (used to determine the MATLAB version) has a bug: it strips only the first character of the version string to retain as a compatibility check. This results in an incorrect encoding where the vers variable only captures the most significant version digit for MATLAB versions 10 and above. 

For example, the current MATLAB version R2024b (version 24) would be parsed as 2. Consequently, in the subsequent if statement, the depreciated fmin function is selected and the script crashes. For MATLAB versions < 100, 10-59 would be affected.

Solution:

Option 1 (preserving backward compatibility): Using functionalities that would be available in legacy MATLAB versions, could update as vers = str2double(datestr(version('-date'), 'yyyy')) to check the release year. This would ensure compatibility with older versions, preserving the intended functionality for fmin.

Option 2 (final solution): However, since fmin has been depreciated for a long time, I opted to remove vers and all its dependencies. The code would now always use fminbnd.